### PR TITLE
Use Workbench inventory instead of player's inventory

### DIFF
--- a/mods/workbench/init.lua
+++ b/mods/workbench/init.lua
@@ -1,17 +1,42 @@
+local function getCraftResult(pos)
+	local inv = minetest.get_meta(pos):get_inventory()
+	inv:set_stack("craftpreview", 1, minetest.get_craft_result({method = "normal", width = 3, items = inv:get_list("craft")}).item)
+end
+
 minetest.register_node("workbench:workbench", {
 	description = "Workbench",
 	tiles = {"workbench_top.png", "workbench_side.png"},
 	stack_max = 64,
 	groups = {choppy=default.dig.workbench,flammable=3},
 	sounds = default.node_sound_wood_defaults(),
-	on_rightclick = function(pos, node, clicker, itemstack)
-		minetest.show_formspec(clicker:get_player_name(), "workbench:workbench",
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("formspec", 
 			"size[9,8;]"..
 			"list[current_player;main;0,3.5;9,3;9]"..
 			"list[current_player;main;0,7;9,1;]"..
-			"list[current_player;craft;4,0;3,3;]"..
-			"list[current_player;craftpreview;7.5,1;1,1;]"
+			"list[context;craft;4,0;3,3;]"..
+			"list[context;craftpreview;7.5,1;1,1;]"
 		)
+		meta:get_inventory():set_size("craft", 9)
+		meta:get_inventory():set_size("craftpreview", 1)
+	end,
+	on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+		getCraftResult(pos)
+	end,
+    	on_metadata_inventory_put = function(pos, listname, index, stack, player)
+		getCraftResult(pos)
+	end,
+   	on_metadata_inventory_take = function(pos, listname, index, stack, player)
+		getCraftResult(pos)
+	end,
+	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
+		if listname == "craftpreview" then return 0 end
+		return stack:get_count()
+	end,
+	can_dig = function(pos,player)
+		local inv = minetest.get_meta(pos):get_inventory()
+		return inv:is_empty("craft") and inv:is_empty("craftpreview")
 	end,
 })
 


### PR DESCRIPTION
Workbenches currently use the player's inventory as the crafting grid and preview slot. Which gave no advantage or purpose for creating multiple Workbenches. Now they each have their own separate crafting inventory allowing them to have separate crafts inside them.
